### PR TITLE
Implement API rate limiting and monitoring.

### DIFF
--- a/.idea/httpRequests/2025-08-09T225130.500.json
+++ b/.idea/httpRequests/2025-08-09T225130.500.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": "2025-08-09T17:21:30.165+00:00",
+  "status": 500,
+  "error": "Internal Server Error",
+  "path": "/api/hello"
+}

--- a/.idea/httpRequests/2025-08-09T225342.500.json
+++ b/.idea/httpRequests/2025-08-09T225342.500.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": "2025-08-09T17:23:42.717+00:00",
+  "status": 500,
+  "error": "Internal Server Error",
+  "path": "/api/hello"
+}

--- a/.idea/httpRequests/2025-08-09T225352.500.json
+++ b/.idea/httpRequests/2025-08-09T225352.500.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": "2025-08-09T17:23:52.580+00:00",
+  "status": 500,
+  "error": "Internal Server Error",
+  "path": "/api/hello"
+}

--- a/.idea/httpRequests/2025-08-09T225401.500.json
+++ b/.idea/httpRequests/2025-08-09T225401.500.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": "2025-08-09T17:24:01.246+00:00",
+  "status": 500,
+  "error": "Internal Server Error",
+  "path": "/api/hello"
+}

--- a/.idea/httpRequests/2025-08-09T230705.200.txt
+++ b/.idea/httpRequests/2025-08-09T230705.200.txt
@@ -1,0 +1,1 @@
+Hello! Your request was allowed by the gateway.

--- a/.idea/httpRequests/2025-08-09T230708.200.txt
+++ b/.idea/httpRequests/2025-08-09T230708.200.txt
@@ -1,0 +1,1 @@
+Hello! Your request was allowed by the gateway.

--- a/.idea/httpRequests/2025-08-09T230709.200.txt
+++ b/.idea/httpRequests/2025-08-09T230709.200.txt
@@ -1,0 +1,1 @@
+Hello! Your request was allowed by the gateway.

--- a/.idea/httpRequests/2025-08-09T230710.200.txt
+++ b/.idea/httpRequests/2025-08-09T230710.200.txt
@@ -1,0 +1,1 @@
+Hello! Your request was allowed by the gateway.

--- a/.idea/httpRequests/2025-08-09T230711.200.txt
+++ b/.idea/httpRequests/2025-08-09T230711.200.txt
@@ -1,0 +1,1 @@
+Hello! Your request was allowed by the gateway.

--- a/.idea/httpRequests/2025-08-09T230712.429.txt
+++ b/.idea/httpRequests/2025-08-09T230712.429.txt
@@ -1,0 +1,1 @@
+Too Many Requests

--- a/.idea/httpRequests/2025-08-09T230750.429.txt
+++ b/.idea/httpRequests/2025-08-09T230750.429.txt
@@ -1,0 +1,1 @@
+Too Many Requests

--- a/.idea/httpRequests/http-client.cookies
+++ b/.idea/httpRequests/http-client.cookies
@@ -1,0 +1,1 @@
+# domain	path	name	value	date

--- a/.idea/httpRequests/http-requests-log.http
+++ b/.idea/httpRequests/http-requests-log.http
@@ -1,0 +1,99 @@
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T230750.429.txt
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T230712.429.txt
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T230711.200.txt
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T230710.200.txt
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T230709.200.txt
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T230708.200.txt
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T230705.200.txt
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T225401.500.json
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T225352.500.json
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T225342.500.json
+
+###
+
+GET http://localhost:8080/api/hello
+User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2024.3.2.2
+Accept-Encoding: br, deflate, gzip, x-gzip
+Accept: */*
+
+<> 2025-08-09T225130.500.json
+
+###
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,18 +10,5 @@ services:
     volumes:
       - redis_data:/data
 
-  postgres:
-    image: "postgres:15-alpine"
-    container_name: rate-limiter-postgres
-    ports:
-      - "5432:5432" # Exposes PostgreSQL on your local machine's port 5432
-    environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: monitoring_db
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
 volumes:
   redis_data:
-  postgres_data:

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -38,7 +38,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/gateway-service/requests.http
+++ b/gateway-service/requests.http
@@ -1,0 +1,3 @@
+    ### Test the Hello endpoint
+    GET http://localhost:8080/api/hello
+    

--- a/gateway-service/src/main/java/com/ratelimiter/gateway_service/GatewayServiceApplication.java
+++ b/gateway-service/src/main/java/com/ratelimiter/gateway_service/GatewayServiceApplication.java
@@ -2,12 +2,14 @@ package com.ratelimiter.gateway_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class GatewayServiceApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(GatewayServiceApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(GatewayServiceApplication.class, args);
+	}
 
 }

--- a/gateway-service/src/main/java/com/ratelimiter/gateway_service/config/AppConfig.java
+++ b/gateway-service/src/main/java/com/ratelimiter/gateway_service/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.ratelimiter.gateway_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/gateway-service/src/main/java/com/ratelimiter/gateway_service/controller/TestController.java
+++ b/gateway-service/src/main/java/com/ratelimiter/gateway_service/controller/TestController.java
@@ -1,4 +1,4 @@
-package com.ratelimiter.gateway_service.controller; // Note the 'controller' package
+package com.ratelimiter.gateway_service.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,9 +7,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 public class TestController {
-
     @GetMapping("/hello")
     public String sayHello() {
-        return "Hello! Your request was allowed.";
+        return "Hello! Your request was allowed by the gateway.";
     }
 }

--- a/gateway-service/src/main/java/com/ratelimiter/gateway_service/dto/RequestLog.java
+++ b/gateway-service/src/main/java/com/ratelimiter/gateway_service/dto/RequestLog.java
@@ -1,0 +1,18 @@
+package com.ratelimiter.gateway_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestLog {
+    private String clientId;
+    private String endpoint;
+    private Instant timestamp;
+    private boolean allowed;
+    private String httpMethod;
+}

--- a/gateway-service/src/main/java/com/ratelimiter/gateway_service/filter/RateLimitingFilter.java
+++ b/gateway-service/src/main/java/com/ratelimiter/gateway_service/filter/RateLimitingFilter.java
@@ -28,7 +28,7 @@ public class RateLimitingFilter extends OncePerRequestFilter {
 
         String clientId = request.getRemoteAddr();
 
-        if (rateLimiter.isAllowed(clientId)) {
+        if (rateLimiter.isAllowed(clientId, request)) {
             filterChain.doFilter(request, response);
         } else {
             log.warn("Rate limit exceeded for client: {}", clientId);

--- a/gateway-service/src/main/java/com/ratelimiter/gateway_service/service/MonitoringClient.java
+++ b/gateway-service/src/main/java/com/ratelimiter/gateway_service/service/MonitoringClient.java
@@ -1,0 +1,25 @@
+package com.ratelimiter.gateway_service.service;
+
+import com.ratelimiter.gateway_service.dto.RequestLog;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MonitoringClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${monitoring-service.url}")
+    private String monitoringServiceUrl;
+
+    @Async
+    public void logRequest(RequestLog requestLog) {
+        restTemplate.postForObject(monitoringServiceUrl + "/log", requestLog, Void.class);
+    }
+}

--- a/gateway-service/src/main/java/com/ratelimiter/gateway_service/service/RedisRateLimiter.java
+++ b/gateway-service/src/main/java/com/ratelimiter/gateway_service/service/RedisRateLimiter.java
@@ -1,7 +1,7 @@
-// The file path is now: ...\gateway_service\service\RedisRateLimiter.java
+package com.ratelimiter.gateway_service.service;
 
-package com.ratelimiter.gateway_service.service; // <-- THIS LINE IS UPDATED
-
+import com.ratelimiter.gateway_service.dto.RequestLog;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -15,20 +15,34 @@ import java.time.Instant;
 public class RedisRateLimiter {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final MonitoringClient monitoringClient;
 
     @Value("${rate-limiter.requests-per-minute}")
     private int maxRequestsPerMinute;
 
-    public boolean isAllowed(String clientId) {
+    public boolean isAllowed(String clientId, HttpServletRequest request) {
         long currentMinute = Instant.now().getEpochSecond() / 60;
         String key = "rate_limit:" + clientId + ":" + currentMinute;
 
         Long currentRequests = redisTemplate.opsForValue().increment(key);
 
-        if (currentRequests != null && currentRequests == 1) {
-            redisTemplate.expire(key, Duration.ofSeconds(60));
+        // Set expiry only for the first request in the window
+        if (currentRequests != null && currentRequests == 1L) {
+            redisTemplate.expire(key, Duration.ofMinutes(1));
         }
 
-        return currentRequests != null && currentRequests <= maxRequestsPerMinute;
+        boolean allowed = currentRequests != null && currentRequests <= maxRequestsPerMinute;
+
+        // Log the request asynchronously to the monitoring service
+        RequestLog requestLog = new RequestLog(
+                clientId,
+                request.getRequestURI(),
+                Instant.now(),
+                allowed,
+                request.getMethod()
+        );
+        monitoringClient.logRequest(requestLog);
+
+        return allowed;
     }
 }

--- a/gateway-service/src/main/resources/application.properties
+++ b/gateway-service/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+spring.application.name=gateway-service
+server.port=8080
+
+rate-limiter.requests-per-minute=5
+
+# Assuming the monitoring-service is running on port 8081
+monitoring-service.url=http://localhost:8081
+
+# Redis Configuration for embedded server
+spring.data.redis.host=localhost
+spring.data.redis.port=6379

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -22,3 +22,12 @@ spring:
 # Custom application properties
 rate-limiter:
   requests-per-minute: 10
+
+monitoring-service:
+  url: http://localhost:8081
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health"

--- a/monitoring-service/pom.xml
+++ b/monitoring-service/pom.xml
@@ -44,8 +44,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/monitoring-service/src/main/java/com/ratelimiter/monitoringservice/controller/AnalyticsController.java
+++ b/monitoring-service/src/main/java/com/ratelimiter/monitoringservice/controller/AnalyticsController.java
@@ -1,0 +1,32 @@
+package com.ratelimiter.monitoringservice.controller;
+
+import com.ratelimiter.monitoringservice.model.RequestLog;
+import com.ratelimiter.monitoringservice.service.RequestLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AnalyticsController {
+
+    private final RequestLogService requestLogService;
+
+    @GetMapping("/")
+    public String home() {
+        return "Monitoring Service is running.";
+    }
+
+    @PostMapping("/log")
+    public void logRequest(@RequestBody RequestLog requestLog) {
+        requestLogService.saveRequestLog(requestLog);
+    }
+
+    @GetMapping("/analytics/{clientId}")
+    public long getRequestCountByClientId(@PathVariable String clientId) {
+        return requestLogService.getRequestCountByClientId(clientId);
+    }
+}

--- a/monitoring-service/src/main/java/com/ratelimiter/monitoringservice/model/RequestLog.java
+++ b/monitoring-service/src/main/java/com/ratelimiter/monitoringservice/model/RequestLog.java
@@ -1,0 +1,28 @@
+package com.ratelimiter.monitoringservice.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String clientId;
+    private String endpoint;
+    private Instant timestamp;
+    private boolean allowed;
+    private String httpMethod;
+}

--- a/monitoring-service/src/main/java/com/ratelimiter/monitoringservice/repository/RequestLogRepository.java
+++ b/monitoring-service/src/main/java/com/ratelimiter/monitoringservice/repository/RequestLogRepository.java
@@ -1,0 +1,9 @@
+package com.ratelimiter.monitoringservice.repository;
+
+import com.ratelimiter.monitoringservice.model.RequestLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequestLogRepository extends JpaRepository<RequestLog, Long> {
+
+    long countByClientId(String clientId);
+}

--- a/monitoring-service/src/main/java/com/ratelimiter/monitoringservice/service/RequestLogService.java
+++ b/monitoring-service/src/main/java/com/ratelimiter/monitoringservice/service/RequestLogService.java
@@ -1,0 +1,21 @@
+package com.ratelimiter.monitoringservice.service;
+
+import com.ratelimiter.monitoringservice.model.RequestLog;
+import com.ratelimiter.monitoringservice.repository.RequestLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RequestLogService {
+
+    private final RequestLogRepository requestLogRepository;
+
+    public void saveRequestLog(RequestLog requestLog) {
+        requestLogRepository.save(requestLog);
+    }
+
+    public long getRequestCountByClientId(String clientId) {
+        return requestLogRepository.countByClientId(clientId);
+    }
+}

--- a/monitoring-service/src/main/resources/application.properties
+++ b/monitoring-service/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=monitoring-service
+server.port=8081
+
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/monitoring-service/src/main/resources/application.yml
+++ b/monitoring-service/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+server:
+  port: 8081
+
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: jdbc:h2:mem:monitoringdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.H2Dialect
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health"


### PR DESCRIPTION
Hi! I've implemented the full API rate-limiting and monitoring flow.
•The gateway-service now uses Redis to limit requests to 5 per minute.
•It asynchronously logs every request (both allowed and denied) to the monitoring-service.
•Added a test controller at /api/hello to verify the functionality.
•The monitoring-service now runs on port 8081 and saves logs to an in-memory H2 database.

The setup requires a local Redis instance to be running.